### PR TITLE
updated tests callable workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Run tests
         id: run-tests
         continue-on-error: true
-        run: ./vendor/bin/pest --ci --coverage --min=30
+        run: ./vendor/bin/pest --ci --coverage --min=${{ vars.MIN_COVERAGE_THRESHOLD || 30 }}
 
       - name: Set outcome
         id: set-outcome


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/tests.yaml` file to make the minimum coverage threshold configurable through a variable. 

* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L47-R47): Modified the `run-tests` step to use the `MIN_COVERAGE_THRESHOLD` variable, defaulting to 30 if the variable is not set.