### PR TITLE
force https in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\URL;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Force HTTPS in production
+        if (config('app.env') === 'production') {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `AppServiceProvider` to enhance security by enforcing HTTPS in production environments.

Security enhancement:

* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR6): Added `use Illuminate\Support\Facades\URL;` to import the `URL` facade.
* `public function register(): void` in `app/Providers/AppServiceProvider.php`: Modified the `boot` method to force HTTPS in production by checking the environment configuration and calling `URL::forceScheme('https');`.