### PR TITLE
security improvement, role update restriction

### DIFF
--- a/resources/views/pages/users/create.blade.php
+++ b/resources/views/pages/users/create.blade.php
@@ -136,13 +136,21 @@
                                 <div>
                                     <label for="role" class="block text-sm font-medium text-gray-700">Rôle</label>
                                     <select name="role" id="role" required
-                                        class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
-                                        <option value="admin" {{ old('role') == 'admin' ? 'selected' : '' }}>
+                                        class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                        {{ auth()->user()->username != session('tenant_id') ? 'disabled' : '' }}>
+                                        <option value="admin" {{ old('role') == 'admin' ? 'selected' : '' }}
+                                            {{ auth()->user()->username != session('tenant_id') ? 'disabled' : '' }}>
                                             Administrateur</option>
-                                        <option value="user" {{ old('role') == 'user' ? 'selected' : '' }}>
+                                        <option value="user"
+                                            {{ old('role') == 'user' || auth()->user()->username != session('tenant_id') ? 'selected' : '' }}>
                                             Utilisateur
                                         </option>
                                     </select>
+                                    @if (auth()->user()->username != session('tenant_id'))
+                                        <p class="mt-1 text-sm text-gray-500">Seul l'administrateur principal peut créer
+                                            des administrateurs.</p>
+                                        <input type="hidden" name="role" value="user">
+                                    @endif
                                 </div>
 
                             </div>

--- a/resources/views/pages/users/edit.blade.php
+++ b/resources/views/pages/users/edit.blade.php
@@ -128,7 +128,8 @@
                                 <div>
                                     <label for="role" class="block text-sm font-medium text-gray-700">Rôle</label>
                                     <select name="role" id="role" required
-                                        class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                        class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                        {{ auth()->user()->username != session('tenant_id') ? 'disabled' : '' }}>
                                         <option value="admin"
                                             {{ old('role', $user->role) == 'admin' ? 'selected' : '' }}>
                                             Administrateur</option>
@@ -137,6 +138,11 @@
                                             Utilisateur
                                         </option>
                                     </select>
+                                    @if (auth()->user()->username != session('tenant_id'))
+                                        <p class="mt-1 text-sm text-gray-500">Seul l'administrateur principal peut
+                                            modifier le rôle d'un utilisateur.</p>
+                                        <input type="hidden" name="role" value="{{ $user->role }}">
+                                    @endif
                                 </div>
 
                                 <div>


### PR DESCRIPTION
This pull request includes changes to the `UserController` and related views to enhance user role and status handling. The main changes focus on ensuring that only the main admin can create or modify admin users, and adding default statuses for new users.

Enhancements to user role and status handling:

* [`app/Http/Controllers/Web/UserController.php`](diffhunk://#diff-fdc981e26ccafb3fb759fbbe7de341627460db6ad16b4e18bfc6680338ef6786L42-R62): Updated the `store` method to enforce that only the main admin can create admin users, and added a default status for new users.
* [`app/Http/Controllers/Web/UserController.php`](diffhunk://#diff-fdc981e26ccafb3fb759fbbe7de341627460db6ad16b4e18bfc6680338ef6786L95-R119): Updated the `update` method to ensure that only the main admin can change user roles, and preserved the existing role and status if the current user is not the main admin. [[1]](diffhunk://#diff-fdc981e26ccafb3fb759fbbe7de341627460db6ad16b4e18bfc6680338ef6786L95-R119) [[2]](diffhunk://#diff-fdc981e26ccafb3fb759fbbe7de341627460db6ad16b4e18bfc6680338ef6786R141-R150)

Updates to user creation and edit views:

* [`resources/views/pages/users/create.blade.php`](diffhunk://#diff-41317ce77a0bae4c32cdabd27d4df359a541424167e9d17d929b6f0adca2bf52L139-R153): Disabled the role selection for non-main admins and added a message indicating that only the main admin can create admin users.
* [`resources/views/pages/users/edit.blade.php`](diffhunk://#diff-57e9bb309e7ff391bd0096cbfab60c4606a3e34ddc0148cfbac08eab6732d51aL131-R132): Disabled the role selection for non-main admins and added a message indicating that only the main admin can modify user roles. [[1]](diffhunk://#diff-57e9bb309e7ff391bd0096cbfab60c4606a3e34ddc0148cfbac08eab6732d51aL131-R132) [[2]](diffhunk://#diff-57e9bb309e7ff391bd0096cbfab60c4606a3e34ddc0148cfbac08eab6732d51aR141-R145)