### PR TITLE
removed env_file in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,6 @@ services:
       - .:/var/www/html
     ports:
       - 80:80
-    env_file:
-      - .env
     # labels:
     #   - "traefik.enable=true"
     #   - "traefik.http.routers.app.rule=Host(`lecoursier.local`)"


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yaml` file. The change involves removing the `env_file` configuration, which previously referenced the `.env` file.

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L19-L20): Removed the `env_file` configuration that referenced the `.env` file.