### PR TITLE
task start and completion endpoints

### DIFF
--- a/app/Http/Controllers/Api/TaskController.php
+++ b/app/Http/Controllers/Api/TaskController.php
@@ -84,4 +84,34 @@ class TaskController extends Controller
             throw new AccessDeniedHttpException();
         }
     }
+
+    /**
+     * Change the status of the task to in progress.
+     */
+    public function start($task)
+    {
+        $taskInstance = Task::findOrFail($task);
+
+        if (request()->user('api')->can('update', $taskInstance)) {
+            $taskInstance->update(['status' => 'in_progress']);
+            return new TaskResource($taskInstance->fresh()->load(['milestone', 'user']));
+        } else {
+            throw new AccessDeniedHttpException();
+        }
+    }
+
+    /**
+     * Change the status of the task to completed.
+     */
+    public function complete($task)
+    {
+        $taskInstance = Task::findOrFail($task);
+
+        if (request()->user('api')->can('update', $taskInstance)) {
+            $taskInstance->update(['status' => 'completed', 'completed_at' => now()]);
+            return new TaskResource($taskInstance->fresh()->load(['milestone', 'user']));
+        } else {
+            throw new AccessDeniedHttpException();
+        }
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,10 @@ Route::middleware(['api.tenant.context', 'api.active.tenant', 'api.tenant.subscr
         // Task routes
         Route::apiResource('tasks', TaskController::class)
             ->middleware('api.auth');
+        Route::post('/tasks/{task}/complete', [TaskController::class, 'complete'])
+            ->middleware('api.auth');
+        Route::post('/tasks/{task}/start', [TaskController::class, 'start'])
+            ->middleware('api.auth');
 
     });
 


### PR DESCRIPTION
This pull request introduces two new endpoints to manage task statuses in the API. Specifically, it adds functionality to mark a task as "in progress" or "completed." The changes include updates to the `TaskController` and the API routes.

### New task status management functionality:

* **`TaskController` Updates**:
  - Added a `start` method to update a task's status to "in progress." It checks user permissions and returns the updated task resource.
  - Added a `complete` method to update a task's status to "completed," including setting a `completed_at` timestamp. It also checks user permissions and returns the updated task resource.

* **API Route Updates**:
  - Added a new POST route `/tasks/{task}/start` to trigger the `start` method in `TaskController`.
  - Added a new POST route `/tasks/{task}/complete` to trigger the `complete` method in `TaskController`.